### PR TITLE
pitch_srh is way faster now!

### DIFF
--- a/feature_extraction/COVAREP_formant_extraction.m
+++ b/feature_extraction/COVAREP_formant_extraction.m
@@ -66,8 +66,7 @@ if(hasParallelComputing)
     parfor n=1:N
         basename=regexp(fileList(n).name,'\.wav','split');
         basename=char(basename(1));
-        str=sprintf('Analysing file: %s',basename);
-        disp(str)
+        disp(['Analysing file: ' basename])
         try
             % Load file and set sample locations
             [x,fs]=audioread([in_dir filesep basename '.wav']);
@@ -77,19 +76,16 @@ if(hasParallelComputing)
             
             wrap_up(basename, in_dir, formantPeaks_int, vowelSpace);
             
-            str=sprintf('.............DONE!!!');
-            disp(str)
-        catch
-            str=sprintf('.............ERROR NOT ANALYSED!!!');
-            disp(str)
+            disp([basename ' successfully analysed'])
+        catch err
+            warning(['An error occurred while analysing ' basename ': ' getReport(err)])
         end
     end
 else
     for n=1:N
         basename=regexp(fileList(n).name,'\.wav','split');
         basename=char(basename(1));
-        str=sprintf('Analysing file: %s',basename);
-        disp(str)
+        disp(['Analysing file: ' basename])
         try
             % Load file and set sample locations
             [x,fs]=audioread([in_dir filesep basename '.wav']);
@@ -99,8 +95,7 @@ else
             
             wrap_up(basename, in_dir, formantPeaks_int, vowelSpace);
             
-            str=sprintf('.............DONE!!!');
-            disp(str)
+            disp([basename ' successfully analysed'])
         catch err
             warning(['An error occurred while analysing ' basename ': ' getReport(err)])
         end

--- a/formant/formant_CGDZP.m
+++ b/formant/formant_CGDZP.m
@@ -90,7 +90,7 @@ for kk=0:numFrames-1
     windowedData=speechData.*blackman(length(speechData));
     
     numPeaks=0;R=Rfix;%the following loop searches for the R value where we have numFormants number of formats
-    while(numPeaks~=numFormants & R>1.01 & R<1.25)
+    while(numPeaks~=numFormants && R>1.01 && R<1.25)
         zeroPhaseData=real(ifft(abs(fft(diff(windowedData)))));%obtain zero-pha version
         %chirp z-transform calculation using fft,...multiplication with an exponential function is sufficient
         exponentialEnvelope=exp(log(1/R)*n)';%this is needed for computation of z-transform using fft
@@ -101,16 +101,16 @@ for kk=0:numFrames-1
         
         [peakIndex]=formantPeakPick(chirpGroupDelay,1);
         numPeaks=length(peakIndex);
-        if(numPeaks>numFormants & R>=Rfix)
+        if(numPeaks>numFormants && R>=Rfix)
             R=R+0.01;peakIndex=peakIndex(1:numFormants);
-        elseif(numPeaks<numFormants & R<=Rfix)
+        elseif(numPeaks<numFormants && R<=Rfix)
             R=R-0.01;peakIndex=[peakIndex zeros(1,numFormants-numPeaks)];
         else
             break;
         end
     end 
     
-    chirpGroupDelay_spectrogram(kk+1,:)=chirpGroupDelay;
+    %chirpGroupDelay_spectrogram(kk+1,:)=chirpGroupDelay;
     
     if(numPeaks>numFormants)
         peakIndex=peakIndex(1:numFormants);
@@ -161,7 +161,7 @@ end
 if(1)%replace possible continuation values instead of zero values
     for kk=2:numFrames-1
         currentPeaks=formantPeaks(kk,:);
-        [val,index]=find(currentPeaks);%finds non-zero elements
+        [~,index]=find(currentPeaks);%finds non-zero elements
         nonZeroFormants=currentPeaks(index);numNonZeroFormants=length(index);
         numZeroFormants=numFormants-numNonZeroFormants;
         if(numNonZeroFormants<numFormants && ~isempty(index))
@@ -184,7 +184,7 @@ if(1)%replace possible continuation values instead of zero values
             if(lenPossibleCandidates<=numZeroFormants)
                 currentPeaks=sort([nonZeroFormants possibleCandidates zeros(1,numZeroFormants-lenPossibleCandidates)]);
             elseif(numZeroFormants==1)%the most common case
-                [val,index]=sort(diff(possibleCandidates));
+                [~,index]=sort(diff(possibleCandidates));
                 currentPeaks=sort([nonZeroFormants possibleCandidates(index(1))]);
             elseif(numZeroFormants<lenPossibleCandidates)
                 possibleCandidates=possibleCandidates(1:numZeroFormants);
@@ -212,16 +212,12 @@ lendiffPhase=length(diffPhase);
 
 peakIndex=[];
 for kk=6:lendiffPhase-6
-    if(diffPhase(kk)>=diffPhase(kk-1) & diffPhase(kk)>=diffPhase(kk+1))%first neighbours
-        if(diffPhase(kk)>=diffPhase(kk-2) & diffPhase(kk)>=diffPhase(kk+2))%second neighbours
-            if(diffPhase(kk)>diffPhase(kk-3) & diffPhase(kk)>diffPhase(kk+3))%third neighbours
-                if(diffPhase(kk)>diffPhase(kk-4) & diffPhase(kk)>diffPhase(kk+4))%fourth neighbours
-                    if(diffPhase(kk)>diffPhase(kk-5) & diffPhase(kk)>diffPhase(kk+5))%fifth neighbours
-                        peakIndex=[peakIndex kk];
-                    end
-                end
-            end
-        end
+    if (diffPhase(kk)>=diffPhase(kk-1) && diffPhase(kk)>=diffPhase(kk+1)) ...%first neighbours
+            && (diffPhase(kk)>=diffPhase(kk-2) && diffPhase(kk)>=diffPhase(kk+2)) ...%second neighbours
+            && (diffPhase(kk)>diffPhase(kk-3) && diffPhase(kk)>diffPhase(kk+3)) ...%third neighbours
+            && (diffPhase(kk)>diffPhase(kk-4) && diffPhase(kk)>diffPhase(kk+4)) ...%fourth neighbours
+            && (diffPhase(kk)>diffPhase(kk-5) && diffPhase(kk)>diffPhase(kk+5))%fifth neighbours
+        peakIndex=[peakIndex kk];
     end
 end
 

--- a/glottalsource/creaky_voice_detection/private/sil_unv_features.m
+++ b/glottalsource/creaky_voice_detection/private/sil_unv_features.m
@@ -66,7 +66,7 @@ Ind=1;
 Es=[];
 Ts=[];
 
-win = hanning(numel(start:stop));
+win = hanning(numel(Start:Stop));
  
 while Stop<length(x)
    

--- a/glottalsource/creaky_voice_detection/private/sil_unv_features.m
+++ b/glottalsource/creaky_voice_detection/private/sil_unv_features.m
@@ -65,6 +65,8 @@ Ind=1;
  
 Es=[];
 Ts=[];
+
+win = hanning(numel(start:stop));
  
 while Stop<length(x)
    
@@ -72,7 +74,7 @@ while Stop<length(x)
     Ts(Ind)=Mid;
    
     Sig=x(Start:Stop); % Select frame segment
-    Sig=Sig(:).*hanning(length(Sig)); % Window segment
+    Sig=Sig(:).*win; % Window segment
 
    
     Es(Ind)=mean(Sig.^2); % Get energy value

--- a/glottalsource/glottal_models/gfm_spec_lf.m
+++ b/glottalsource/glottal_models/gfm_spec_lf.m
@@ -52,7 +52,7 @@
 %  Make the computation independent from T0 (for better numerical stability)
 %
 
-function G = gfm_spec_lf(f, fs, T0, Ee, te, tp, ta);
+function G = gfm_spec_lf(f, fs, T0, Ee, te, tp, ta)
 
     Te = te*T0;
     Tp = tp*T0;
@@ -74,10 +74,10 @@ function G = gfm_spec_lf(f, fs, T0, Ee, te, tp, ta);
     E0 = -Ee/(exp(a*Te)*sin(wg*Te));                % [1](5)
 
     % LF spectrum formula                           % [2](1)
-    P1 = E0*(1./((a - j*2*pi.*f).^2 + wg^2));
-    P2 = (wg + exp((a - j*2*pi.*f)*Te).*((a - j*2*pi.*f)*sin(wg*Te) - wg*cos(wg*Te)));
-    P3 = (Ee*(exp( - j*2*pi.*f*Te)./((e*Ta*j*2*pi*f).*(e + j*2*pi.*f))));
-    P4 = (e*(1 - e*Ta).*(1 - exp(- j*2*pi.*f*(T0 - Te))) - e*Ta*j*2*pi.*f);
+    P1 = E0*(1./((a - 1i*2*pi.*f).^2 + wg^2));
+    P2 = (wg + exp((a - 1i*2*pi.*f)*Te).*((a - 1i*2*pi.*f)*sin(wg*Te) - wg*cos(wg*Te)));
+    P3 = (Ee*(exp( - 1i*2*pi.*f*Te)./((e*Ta*1i*2*pi*f).*(e + 1i*2*pi.*f))));
+    P4 = (e*(1 - e*Ta).*(1 - exp(- 1i*2*pi.*f*(T0 - Te))) - e*Ta*1i*2*pi.*f);
     G = P1.*P2 + P3.*P4;
 
     % Fix the amplitude so as Ee is respected

--- a/glottalsource/lpcresidual.m
+++ b/glottalsource/lpcresidual.m
@@ -55,10 +55,11 @@ LPCcoeff=zeros(order+1,round(length(x)/shift));
 
 %% Do processing
 n=1;
+win = hanning(numel(start:stop));
 while stop<length(x)
 
      segment=x(start:stop);
-     segment=segment.*hanning(length(segment));
+     segment=segment.*win;
         
      A=lpc(segment,order);
      LPCcoeff(:,n)=A(:);

--- a/glottalsource/pitch_srh.m
+++ b/glottalsource/pitch_srh.m
@@ -115,6 +115,7 @@ clear res;
 %% Create window matrix and apply to frames
 win = blackman(frameDuration);
 frameMatWin = bsxfun(@times, frameMat, win);
+clear frameMat;
 
 %% Do mean subtraction
 frameMean = mean(frameMatWin,1);
@@ -122,12 +123,14 @@ frameMatWinMean = bsxfun(@minus, frameMatWin, frameMean);
 clear frameMean frameMatWin frameMat;
 
 %% Compute spectrogram matrix
-specMat = zeros(fs, size(frameMatWinMean,2));
+specMat = zeros(fs/2, size(frameMatWinMean,2));
 for i = 1:size(frameMatWinMean,2)
-    specMat(:,i) = abs( fft(frameMatWinMean(:,i),fs) )';
+    tmp = abs( fft(frameMatWinMean(:,i),fs) )';
+    specMat(:,i) = tmp(1:fs/2);
 end
+clear frameMatWinMean tmp;
 % specMat = abs( fft(frameMatWinMean,fs) );
-specMat = specMat(1:fs/2,:);
+% specMat = specMat(1:fs/2,:);
 specDenom = sqrt( sum( specMat.^2, 1 ) );
 specMat = bsxfun(@rdivide, specMat, specDenom);
 clear specDenom;
@@ -151,7 +154,7 @@ for Iter=1:Niter
     end
     
 end
-
+clear specMat;
 time=time/fs;
 
 %% Voiced-Unvoiced decisions are derived from the value of SRH (Summation of
@@ -164,7 +167,7 @@ end
 
 VUVDecisions( SRHVal > VoicingThresh ) = 1;
 
-return
+end
 
 
 function [F0,SRHVal] = SRH( specMat, nHarmonics, f0min, f0max )
@@ -199,6 +202,6 @@ end
 % Retrieve f0 and SRH value
 [SRHVal,F0] = max( SRHmat );
 
-return
+end
 
 

--- a/glottalsource/pitch_srh.m
+++ b/glottalsource/pitch_srh.m
@@ -180,14 +180,18 @@ SRHmat = zeros(f0max,N);
 fSeq = f0min:f0max;
 fLen = length(fSeq);
 
-% Prepare harmonic indeces matrices. 
+% Prepare harmonic indeces matrices.
 plusIdx = repmat( (1:nHarmonics)',1,fLen) .* repmat(fSeq,nHarmonics,1);
 subtrIdx = round( repmat( (1:nHarmonics-1)'+.5,1,fLen) .* ...
                   repmat(fSeq,nHarmonics-1,1) );
 
+% avoid costly repmat operation by adjusting indices
+plusIdx = mod(plusIdx-1,size(specMat,1))+1;
+subtrIdx = mod(subtrIdx-1,size(specMat,1))+1;
+
 % Do harmonic summation
 for n=1:N
-    specMatCur = repmat( specMat(:,n),1,fLen);
+    specMatCur = specMat(:,n);
     SRHmat(fSeq,n) = ( sum( specMatCur(plusIdx), 1 ) - ...
                        sum( specMatCur(subtrIdx), 1 ) )';
 end

--- a/glottalsource/polarity_reskew.m
+++ b/glottalsource/polarity_reskew.m
@@ -105,6 +105,7 @@ function polarity = polarity_reskew(s, fs, opt)
 
     start=1;
     stop=start+L;
+    win = hanning(numel(start:stop));
 
     res=zeros(1,length(wave));
     LPCcoeff=zeros(order+1,round(length(wave)/shift));
@@ -112,10 +113,10 @@ function polarity = polarity_reskew(s, fs, opt)
     while stop<length(wave)
         
         segment=waveToComputeLPC(start:stop);
-        segment=segment.*hanning(length(segment));
+        segment=segment.*win;
         
         segment2=wave(start:stop);
-        segment2=segment2.*hanning(length(segment2));    
+        segment2=segment2.*win;    
         
         [A]=lpc(segment,order);
         LPCcoeff(:,n)=A(:);

--- a/vocoder/hmpd/private/philin2philog.m
+++ b/vocoder/hmpd/private/philin2philog.m
@@ -59,7 +59,7 @@ function philog = philin2philog(philin, Hb, Hmax, order)
     hsl = round(hsl);
     philog = nan(1,order);
     for h=1:order
-        idx = find(hsl==h);
+        idx = hsl==h;
         philog(h) = angle(mean(exp(1i*philin(idx))));
     end
 


### PR DESCRIPTION
The repmat operation in SRH used for the harmonic summation was the slowest part of pitch_srh. I replaced this repmat operation by indexing the matrix in a better way. Another issue in pitch_shr is that only half of the (very large) spectrogram matrix is used, but the entire matrix is allocated. I fixed this by allocating only half of the matrix.

Additional to the change in pitch_srh, I applied the same error forwarding to the parallel case in the formant extraction. Some logical expressions in formant_CGDZP.m use the short circuit evaluation. Lastly, the hanning windows in lpcresidual.m and polarity_reskew.m do not change over time. Therefore, it is faster to use a static window.