### PR TITLE
gci_sedreams can be dramatically faster at the cost of small numeric issues

### DIFF
--- a/formant/formant_CGDZP.m
+++ b/formant/formant_CGDZP.m
@@ -82,16 +82,18 @@ SIZEwave=length(wave);
 numFrames=floor((SIZEwave-frameSize)/frameShift);
 
 t_analysis=zeros(1,numFrames);
+blackWin = blackman(frameSize);
 
 formantPeaks=[];
 for kk=0:numFrames-1
     
     speechData=wave(kk*frameShift+1:kk*frameShift+frameSize);
-    windowedData=speechData.*blackman(length(speechData));
+    windowedData=speechData.*blackWin;
+    
+    zeroPhaseData=real(ifft(abs(fft(diff(windowedData)))));%obtain zero-pha version
     
     numPeaks=0;R=Rfix;%the following loop searches for the R value where we have numFormants number of formats
     while(numPeaks~=numFormants && R>1.01 && R<1.25)
-        zeroPhaseData=real(ifft(abs(fft(diff(windowedData)))));%obtain zero-pha version
         %chirp z-transform calculation using fft,...multiplication with an exponential function is sufficient
         exponentialEnvelope=exp(log(1/R)*n)';%this is needed for computation of z-transform using fft
         fourierTrans=fft(zeroPhaseData.*exponentialEnvelope,fsLR);

--- a/glottalsource/creaky_voice_detection/private/creaky_voice_do_detection.m
+++ b/glottalsource/creaky_voice_detection/private/creaky_voice_do_detection.m
@@ -77,7 +77,7 @@ for k=1:m(1)
     mini=Minis(k);
     maxi=Maxis(k);
     
-    pos=find(isnan(vec));
+    pos=isnan(vec);
     vec(pos)=mini;
     
     X(k,:)=-1+((vec-mini)/(maxi-mini))*2;

--- a/glottalsource/creaky_voice_detection/private/get_short_pow.m
+++ b/glottalsource/creaky_voice_detection/private/get_short_pow.m
@@ -52,24 +52,22 @@ function [pow,pow_std,pow_std_inter] = get_short_pow(x,fs)
 veryShort_len = 4*(fs/1000); % 4ms frame length for "very short-term" analysis
 veryShort_shift = 2*(fs/1000); % 2ms shift for "very short-term" analysis
 veryShort_powCont = zeros(1,ceil((length(x)-veryShort_len)/veryShort_shift));
-t_pow = zeros(1,ceil((length(x)-veryShort_len)/veryShort_shift));
 start=1;
 finish=start+veryShort_len-1;
 
 n=1;
+x2 = x.^2;
 while finish <= length(x)
-    veryShort_powCont(n) = mean(x(start:finish).^2);
-    t_pow(n)=mean([start finish]);
+    veryShort_powCont(n) = mean(x2(start:finish));
     start = start + veryShort_shift;
     finish=start+veryShort_len-1;
     n=n+1;
 end
+clear x2;
 
 pow = 20*log10(veryShort_powCont);
-inf_idx=find(isinf(pow));
-pow2=pow;
-pow2(inf_idx)=Inf;
-pow(inf_idx)=min(pow2);
+inf_idx=isinf(pow);
+pow(inf_idx)=min(pow(~inf_idx));
 
 pow_std=zeros(1,length(pow));
 std_len=16;

--- a/glottalsource/creaky_voice_detection/private/ishi_creak_detection.m
+++ b/glottalsource/creaky_voice_detection/private/ishi_creak_detection.m
@@ -76,13 +76,15 @@ finish=start+veryShort_len-1;
 
 % Get very short term power contour
 n=1;
+x_filt2 = x_filt.^2;
 while finish <= length(x_filt)
-    veryShort_powCont(n) = mean(x_filt(start:finish).^2);
+    veryShort_powCont(n) = mean(x_filt2(start:finish));
     t_pow(n)=mean([start finish]);
     start = start + veryShort_shift;
     finish=start+veryShort_len-1;
     n=n+1;
 end
+clear x_filt2;
 
 veryShort_powCont_dB = 20*log10(veryShort_powCont);
 

--- a/glottalsource/creaky_voice_detection/private/sil_unv_features.m
+++ b/glottalsource/creaky_voice_detection/private/sil_unv_features.m
@@ -62,11 +62,11 @@ pos=mean([Start Stop]);
 ZCs_ms=ZCs/1000*fs;
 
 Ind=1;
- 
-Es=zeros(1,numel(Stop:Shift:length(x)));
+
+Es=zeros(1,floor((length(x)-Stop+1)/Shift)+1);
 Ts=zeros(size(Es));
 
-win = hanning(numel(Start:Stop));
+win = hanning(Stop-Start+1);
  
 while Stop<length(x)
    
@@ -84,5 +84,5 @@ while Stop<length(x)
     pos(Ind)=mean([Start Stop]);
     Ind=Ind+1;
 end 
- 
+
 Es=log(Es);

--- a/glottalsource/creaky_voice_detection/private/sil_unv_features.m
+++ b/glottalsource/creaky_voice_detection/private/sil_unv_features.m
@@ -63,8 +63,8 @@ ZCs_ms=ZCs/1000*fs;
 
 Ind=1;
  
-Es=[];
-Ts=[];
+Es=zeros(1,numel(Stop:Shift:length(x)));
+Ts=zeros(size(Es));
 
 win = hanning(numel(Start:Stop));
  

--- a/glottalsource/gci_sedreams.m
+++ b/glottalsource/gci_sedreams.m
@@ -92,16 +92,14 @@ function [gci, MeanBasedSignal, res] = gci_sedreams(wave, fs, f0mean, ...
     res(isnan(res))=0;
 
     % Calculation of the mean-based signal
-    MeanBasedSignal=zeros(1,length(wave));
     T0mean=round(fs/f0mean);
-
     halfL=round((1.7*T0mean)/2);
     Blackwin=blackman(2*halfL+1);
 
     % filter wave with blackwin and take mean
     MeanBasedSignal = filter(Blackwin,numel(Blackwin),wave)';
     % shift output since MATLAB's filter 'center' is the first element
-    MeanBasedSignal(halfL:end-halfL) = MeanBasedSignal(2*halfL:end);
+    MeanBasedSignal(halfL+1:end-halfL) = MeanBasedSignal(1+2*halfL:end);
     % and pad begin and end with zeros
     MeanBasedSignal([1:halfL end-halfL+1:end]) = 0;
     

--- a/glottalsource/gci_sedreams.m
+++ b/glottalsource/gci_sedreams.m
@@ -98,13 +98,13 @@ function [gci, MeanBasedSignal, res] = gci_sedreams(wave, fs, f0mean, ...
     halfL=round((1.7*T0mean)/2);
     Blackwin=blackman(2*halfL+1);
 
-    for m=halfL+1:length(wave)-halfL
-        vec=wave(m-halfL:m+halfL);
-            
-        vec=vec.*Blackwin;
-        MeanBasedSignal(m)=mean(vec);
-    end
-
+    % filter wave with blackwin and take mean
+    MeanBasedSignal = filter(Blackwin,numel(Blackwin),wave)';
+    % shift output since MATLAB's filter 'center' is the first element
+    MeanBasedSignal(halfL:end-halfL) = MeanBasedSignal(2*halfL:end);
+    % and pad begin and end with zeros
+    MeanBasedSignal([1:halfL end-halfL+1:end]) = 0;
+    
     % Remove the low-frequency contents of the mean-based signal
     Ws = 30/(fs/2);
     Wp = 50/(fs/2);
@@ -114,9 +114,6 @@ function [gci, MeanBasedSignal, res] = gci_sedreams(wave, fs, f0mean, ...
 
     MeanBasedSignal=filtfilt(b,a,MeanBasedSignal);
     MeanBasedSignal=MeanBasedSignal/max(abs(MeanBasedSignal));
-
-
-
 
     % Detect the minima and maxima of the mean-based signal
     PotMaxis=[];
@@ -194,5 +191,5 @@ function [gci, MeanBasedSignal, res] = gci_sedreams(wave, fs, f0mean, ...
 
     gci = (gci-1)/fs;
 
-return
+end
 

--- a/glottalsource/gci_sedreams.m
+++ b/glottalsource/gci_sedreams.m
@@ -114,18 +114,8 @@ function [gci, MeanBasedSignal, res] = gci_sedreams(wave, fs, f0mean, ...
     MeanBasedSignal=MeanBasedSignal/max(abs(MeanBasedSignal));
 
     % Detect the minima and maxima of the mean-based signal
-    PotMaxis=[];
-    PotMinis=[];
-
-    for m=2:length(MeanBasedSignal)-1    
-        if (MeanBasedSignal(m)>MeanBasedSignal(m-1)) && ...
-                (MeanBasedSignal(m)>MeanBasedSignal(m+1))
-            PotMaxis=[PotMaxis m];
-        elseif (MeanBasedSignal(m)<MeanBasedSignal(m-1)) && ...
-                (MeanBasedSignal(m)<MeanBasedSignal(m+1))
-            PotMinis=[PotMinis m];
-        end
-    end
+    [~,PotMaxis]=findpeaks(MeanBasedSignal);
+    [~,PotMinis]=findpeaks(-MeanBasedSignal);
 
     while PotMaxis(1)<PotMinis(1)
         PotMaxis(1)=[];

--- a/glottalsource/get_vq_params.m
+++ b/glottalsource/get_vq_params.m
@@ -142,10 +142,7 @@ for n=1:length(GCI)
         [h_idx,h_amp]=v_findpeaks(f_spec,[],F0/2);
         HRF_harm_num=floor(HRF_freq_max/F0);
         if length(h_idx) >= min_harm_num
-            f0_idx=zeros(HRF_harm_num,1);
-            for m=1:HRF_harm_num
-                [~,f0_idx(m)]=min(abs(h_idx-(F0*m))); % Find closest peak to F0
-            end
+            [~,f0_idx] = min(abs(bsxfun(@minus,h_idx,(1:HRF_harm_num)*F0)),[],1);
             H1H2(n)=h_amp(f0_idx(1))-h_amp(f0_idx(2));
             HRF(n) = sum(h_amp(f0_idx(2:end)))/h_amp(f0_idx(1));
         end
@@ -217,17 +214,27 @@ flag = 0;
 N = 3; % An set to an initial value of 3, as per Alku et al (1997)
 X=X(:);
 
+X2=X.^2;
+k2_sum=sum((0:N-2).^2);
+
 %% Do processing
 while flag == 0
-	k = 0:N-1;
+    k = (0:N-1)';
   
-    % Equation 5
-    k=k(:);   
-    a = (N*sum(X(k+1).*k.^2)-sum(X(k+1)).*sum(k.^2))/(N*sum(k.^4)-(sum(k.^2)).^2); 
-  
+    k2= k.^2;
+    k2_sum= k2_sum + k2(end);
+    
+    k1 = k+1;
+    X_k1 = X(k1);
+    
+    % Equation 5 
+    a = (N*sum(X_k1.*k2)-sum(X_k1).*k2_sum)/(N*sum(k2.^2)-k2_sum.^2); 
+    
+    X_k1_a_k2 = X_k1-a*k2;
+    
     % Equation 4
-    b = 1/N*sum(X(k+1)-a*k.^2);
-    NE = (sum((X(k+1)-a*k.^2-b).^2))/(sum(X(k+1).^2));
+    b = 1/N*sum(X_k1_a_k2);
+    NE = (sum((X_k1_a_k2-b).^2))/(sum(X2(k1)));
 
     % Increment or stop
     if NE < NE_min

--- a/glottalsource/get_vq_params.m
+++ b/glottalsource/get_vq_params.m
@@ -215,26 +215,42 @@ N = 3; % An set to an initial value of 3, as per Alku et al (1997)
 X=X(:);
 
 X2=X.^2;
-k2_sum=sum((0:N-2).^2);
+k = (0:N-2)';
+k2 = k.^2;
+k2_sum=sum(k2);
+k4 = k2.^2;
+k4_sum=sum(k4);
+k1 = k+1;
+X_k1_sum = sum(X(k1));
+X_k1_k2_sum = sum(X(k1).*k2);
+X2_k1_sum = sum(X2(k1));
 
 %% Do processing
 while flag == 0
     k = (0:N-1)';
   
+    % iteratively built sum
     k2= k.^2;
     k2_sum= k2_sum + k2(end);
     
+    k4 = k2.^2;
+    k4_sum= k4_sum + k4(end);
+    
     k1 = k+1;
     X_k1 = X(k1);
+    X_k1_sum = X_k1_sum + X_k1(end);
+    X_k1_k2_sum = X_k1_k2_sum + X_k1(end)*k2(end);
+    
+    X2_k1_sum = X2_k1_sum + X2(k1(end));
     
     % Equation 5 
-    a = (N*sum(X_k1.*k2)-sum(X_k1).*k2_sum)/(N*sum(k2.^2)-k2_sum.^2); 
+    a = (N*X_k1_k2_sum-X_k1_sum.*k2_sum)/(N*k4_sum-k2_sum.^2); 
     
     X_k1_a_k2 = X_k1-a*k2;
     
     % Equation 4
     b = 1/N*sum(X_k1_a_k2);
-    NE = (sum((X_k1_a_k2-b).^2))/(sum(X2(k1)));
+    NE = (sum((X_k1_a_k2-b).^2))/X2_k1_sum;
 
     % Increment or stop
     if NE < NE_min

--- a/glottalsource/iaif.m
+++ b/glottalsource/iaif.m
@@ -117,14 +117,16 @@ end
 % diminish ripple in the beginning of the frame. The ramp is removed after
 % filtering.
 if length(x)>p_vt
-    Hg1 = lpc(x.*hanning(length(x)),1);
+    win = hanning(length(x));
+    
+    Hg1 = lpc(x.*win,1);
     y = filter(Hg1,1,[linspace(-x(1),x(1),preflt)' ; x]);
     y = y(preflt+1:end);
 
     % Estimate the effect of the vocal tract (Hvt1) and cancel it out through
     % inverse filtering. The effect of the lip radiation is canceled through
     % intergration. Signal g1 is the first estimate of the glottal flow.
-    Hvt1 = lpc(y.*hanning(length(x)),p_vt);
+    Hvt1 = lpc(y.*win,p_vt);
     g1 = filter(Hvt1,1,[linspace(-x(1),x(1),preflt)' ; x]);
     g1 = filter(1,[1 -d],g1);
     g1 = g1(preflt+1:end);
@@ -132,7 +134,7 @@ if length(x)>p_vt
     % Re-estimate the effect of the glottal flow (Hg2). Cancel the contribution
     % of the glottis and the lip radiation through inverse filtering and
     % integration, respectively.
-    Hg2 = lpc(g1.*hanning(length(x)),p_gl);
+    Hg2 = lpc(g1.*win,p_gl);
     y = filter(Hg2,1,[linspace(-x(1),x(1),preflt)' ; x]);
     y = filter(1,[1 -d],y);
     y = y(preflt+1:end);
@@ -140,7 +142,7 @@ if length(x)>p_vt
     % Estimate the model for the vocal tract (Hvt2) and cancel it out through
     % inverse filtering. The final estimate of the glottal flow is obtained
     % through canceling the effect of the lip radiation.
-    Hvt2 = lpc(y.*hanning(length(x)),p_vt);
+    Hvt2 = lpc(y.*win,p_vt);
     dg = filter(Hvt2,1,[linspace(-x(1),x(1),preflt)' ; x]);
     g = filter(1,[1 -d],dg);
     g = g(preflt+1:end);

--- a/glottalsource/iaif.m
+++ b/glottalsource/iaif.m
@@ -118,35 +118,37 @@ end
 % filtering.
 if length(x)>p_vt
     win = hanning(length(x));
+    signal = [linspace(-x(1),x(1),preflt)' ; x];
+    idx = preflt+1:numel(signal);
     
     Hg1 = lpc(x.*win,1);
-    y = filter(Hg1,1,[linspace(-x(1),x(1),preflt)' ; x]);
-    y = y(preflt+1:end);
+    y = filter(Hg1,1,signal);
+    y = y(idx);
 
     % Estimate the effect of the vocal tract (Hvt1) and cancel it out through
     % inverse filtering. The effect of the lip radiation is canceled through
     % intergration. Signal g1 is the first estimate of the glottal flow.
     Hvt1 = lpc(y.*win,p_vt);
-    g1 = filter(Hvt1,1,[linspace(-x(1),x(1),preflt)' ; x]);
+    g1 = filter(Hvt1,1,signal);
     g1 = filter(1,[1 -d],g1);
-    g1 = g1(preflt+1:end);
+    g1 = g1(idx);
 
     % Re-estimate the effect of the glottal flow (Hg2). Cancel the contribution
     % of the glottis and the lip radiation through inverse filtering and
     % integration, respectively.
     Hg2 = lpc(g1.*win,p_gl);
-    y = filter(Hg2,1,[linspace(-x(1),x(1),preflt)' ; x]);
+    y = filter(Hg2,1,signal);
     y = filter(1,[1 -d],y);
-    y = y(preflt+1:end);
+    y = y(idx);
 
     % Estimate the model for the vocal tract (Hvt2) and cancel it out through
     % inverse filtering. The final estimate of the glottal flow is obtained
     % through canceling the effect of the lip radiation.
     Hvt2 = lpc(y.*win,p_vt);
-    dg = filter(Hvt2,1,[linspace(-x(1),x(1),preflt)' ; x]);
+    dg = filter(Hvt2,1,signal);
     g = filter(1,[1 -d],dg);
     g = g(preflt+1:end);
-    dg = dg(preflt+1:end);
+    dg = dg(idx);
 
     % Set vocal tract model to 'a' and glottal source spectral model to 'ag'
     a = Hvt2;

--- a/glottalsource/iaif_gci.m
+++ b/glottalsource/iaif_gci.m
@@ -71,6 +71,7 @@ gd=zeros(1,length(x));
 g=zeros(1,length(x));
 a=zeros(p_vt+1,N);
 ag=zeros(p_gl+1,N);
+hpfilter_out = [];
 
 %% Do processing
 for n=1:N
@@ -94,7 +95,7 @@ for n=1:N
     x_win=x_frame(:).*hanning(length(x_frame));
     
     % Do IAIF
-    [g_frame,gd_frame,a_frame,ag_frame]=iaif(x_win,fs,p_vt,p_gl,d,hpfilt);
+    [g_frame,gd_frame,a_frame,ag_frame,hpfilter_out]=iaif(x_win,fs,p_vt,p_gl,d,hpfilt,hpfilter_out);
     if isempty(g_frame)==0
         a(:,n)=a_frame(:);
         ag(:,n)=ag_frame(:);

--- a/glottalsource/lpcresidual.m
+++ b/glottalsource/lpcresidual.m
@@ -55,7 +55,7 @@ LPCcoeff=zeros(order+1,round(length(x)/shift));
 
 %% Do processing
 n=1;
-win = hanning(numel(start:stop));
+win = hanning(stop-start+1);
 while stop<length(x)
 
      segment=x(start:stop);

--- a/glottalsource/peakslope.m
+++ b/glottalsource/peakslope.m
@@ -71,8 +71,7 @@ y=zeros(length(i),length(s)); % Allocate space for the different frequency bands
 
 for n=1:length(i) 
     h_i = daless_MW(i,n,fs); % Generate mother wavelet
-    y_i = do_daless_filt(s,h_i); % Carry out zero-phase filtering
-    y(n,:) = y_i;
+    y(n,:) = do_daless_filt(s,h_i); % Carry out zero-phase filtering
 end
 
 %% Measure peakSlope per frame
@@ -96,9 +95,9 @@ while finish <= length(s)
     start = start+frameShift;
     finish = start+frameLen-1;
 end
-PS(find(isnan(PS(:,2))),2)=0;
+PS(isnan(PS(:,2)),2)=0;
 
-return
+end
 
 % Changes
 % 2012-11-01> John Kane kanejo@tcd.ie

--- a/glottalsource/peakslope.m
+++ b/glottalsource/peakslope.m
@@ -80,11 +80,7 @@ finish = start+frameLen-1;
 m=1;
 
 while finish <= length(s)
-    maxima = zeros(1,length(i)); % allocate space
-    
-    for n=1:length(i)
-        maxima(n) = max(abs(y(n,start:finish))); % measure peaks at each scale
-    end
+    maxima = max(abs(y(:,start:finish)),[],2)';
     maxima = log10(maxima(end:-1:1)); % reverse order to follow frequency order and convert to dB
     t=1:length(maxima);
     p=polyfit(t,maxima,1); % do straight line regression fitting

--- a/glottalsource/pitch_srh.m
+++ b/glottalsource/pitch_srh.m
@@ -124,11 +124,12 @@ clear frameMean frameMatWin frameMat;
 
 %% Compute spectrogram matrix
 specMat = zeros(fs/2, size(frameMatWinMean,2));
+idx = 1:fs/2;
 for i = 1:size(frameMatWinMean,2)
     tmp = abs( fft(frameMatWinMean(:,i),fs) )';
-    specMat(:,i) = tmp(1:fs/2);
+    specMat(:,i) = tmp(idx);
 end
-clear frameMatWinMean tmp;
+clear frameMatWinMean tmp idx;
 % specMat = abs( fft(frameMatWinMean,fs) );
 % specMat = specMat(1:fs/2,:);
 specDenom = sqrt( sum( specMat.^2, 1 ) );

--- a/glottalsource/pitch_srh.m
+++ b/glottalsource/pitch_srh.m
@@ -126,7 +126,7 @@ clear frameMean frameMatWin frameMat;
 specMat = zeros(fs/2, size(frameMatWinMean,2));
 idx = 1:fs/2;
 for i = 1:size(frameMatWinMean,2)
-    tmp = abs( fft(frameMatWinMean(:,i),fs) )';
+    tmp = abs( fft(frameMatWinMean(:,i),fs) );
     specMat(:,i) = tmp(idx);
 end
 clear frameMatWinMean tmp idx;

--- a/glottalsource/polarity_reskew.m
+++ b/glottalsource/polarity_reskew.m
@@ -105,7 +105,7 @@ function polarity = polarity_reskew(s, fs, opt)
 
     start=1;
     stop=start+L;
-    win = hanning(numel(start:stop));
+    win = hanning(stop-start+1);
 
     res=zeros(1,length(wave));
     LPCcoeff=zeros(order+1,round(length(wave)/shift));

--- a/sinusoidal/sin2shm.m
+++ b/sinusoidal/sin2shm.m
@@ -30,7 +30,7 @@
 %  Manage holes in the harmonic structure
 %
 
-function [M opt] = sin2shm(sins, opt)
+function [M, opt] = sin2shm(sins, opt)
 
     if nargin<2
         opt.nbh             = Inf; % Number of harmonics to be use in the model
@@ -49,7 +49,7 @@ function [M opt] = sin2shm(sins, opt)
     % TODO manage holes in the harmonic structure
 
     if ~isempty(opt.max_freq) && opt.max_freq>0
-        inds = find(sins(1,:)<=opt.max_freq);
+        inds = sins(1,:)<=opt.max_freq;
         sins = sins(:,inds);
     end
     sins = sins(:,1:min(size(sins,2), 1+opt.nbh));

--- a/vocoder/hmpd/private/hmpd_features_compress.m
+++ b/vocoder/hmpd/private/hmpd_features_compress.m
@@ -97,7 +97,7 @@ function [AEC, PDMC, PDDC] = hmpd_features_compress(f0s, AE, PDM, PDD, fs, opt)
         for n=1:size(PDD,1)
             X = PDD(n,:);
             X(1) = X(2);
-            idx = find(X==0);
+            idx = X==0;
             X(idx) = 0.001;
             PDDC(n,1:1+opt.pdd_order) = hspec2fwcep(X, fs, opt.pdd_order);
             if 0


### PR DESCRIPTION
In gci_sedreams the signal is manually filtered with a blackman window in a for-loop. The same can be achieved much faster by using MATLAB's built-in function 'filter'. However, the output (MeanBasedSignal) seems to be slightly different, probably due to numeric issues. Since only the peaks of this vector are used, I assume it will not affect the further processing. On my laptop the old code took 16.77sec (with a 10sec test file) while the new code took only 0.03sec.

Please feel free to reject this pull request since the output might be slightly different! If you accept this pull request, please double check my changes!