### PR TITLE
plain fzero function speeds up calculation of Rd

### DIFF
--- a/glottalsource/get_vq_params.m
+++ b/glottalsource/get_vq_params.m
@@ -214,39 +214,40 @@ flag = 0;
 N = 3; % An set to an initial value of 3, as per Alku et al (1997)
 X=X(:);
 
+% pre-allocate&compute
 X2=X.^2;
-k = (0:N-2)';
+k = (0:100)';
 k2 = k.^2;
-k2_sum=sum(k2);
 k4 = k2.^2;
-k4_sum=sum(k4);
-k1 = k+1;
-X_k1_sum = sum(X(k1));
-X_k1_k2_sum = sum(X(k1).*k2);
-X2_k1_sum = sum(X2(k1));
+
+% init sum
+k2_sum=sum(k2(1:N-1));
+k4_sum=sum(k4(1:N-1));
+X_k1_sum = sum(X(1:N-1));
+X_k1_k2_sum = sum(X((1:N-1)).*k2(1:N-1));
+X2_k1_sum = sum(X2((1:N-1)));
 
 %% Do processing
 while flag == 0
-    k = (0:N-1)';
+
+    % re-allocate if necessary
+    if N>numel(k)
+        k = (0:numel(k)*2)';
+        k2 = k.^2;
+        k4 = k2.^2;
+    end
   
     % iteratively built sum
-    k2= k.^2;
-    k2_sum= k2_sum + k2(end);
-    
-    k4 = k2.^2;
-    k4_sum= k4_sum + k4(end);
-    
-    k1 = k+1;
-    X_k1 = X(k1);
-    X_k1_sum = X_k1_sum + X_k1(end);
-    X_k1_k2_sum = X_k1_k2_sum + X_k1(end)*k2(end);
-    
-    X2_k1_sum = X2_k1_sum + X2(k1(end));
+    k2_sum= k2_sum + k2(N);
+    k4_sum= k4_sum + k4(N);
+    X_k1_sum = X_k1_sum + X(N);
+    X_k1_k2_sum = X_k1_k2_sum + X(N)*k2(N);
+    X2_k1_sum = X2_k1_sum + X2(N);
     
     % Equation 5 
     a = (N*X_k1_k2_sum-X_k1_sum.*k2_sum)/(N*k4_sum-k2_sum.^2); 
     
-    X_k1_a_k2 = X_k1-a*k2;
+    X_k1_a_k2 = X(1:N)-a*k2(1:N);
     
     % Equation 4
     b = 1/N*sum(X_k1_a_k2);

--- a/glottalsource/get_vq_params.m
+++ b/glottalsource/get_vq_params.m
@@ -216,13 +216,11 @@ X=X(:);
 
 % pre-allocate&compute
 X2=X.^2;
-k = (0:100)';
-k2 = k.^2;
-k4 = k2.^2;
+k2 = ((0:100).^2)';
 
 % init sum
 k2_sum=sum(k2(1:N-1));
-k4_sum=sum(k4(1:N-1));
+k4_sum=sum(k2(1:N-1).^2);
 X_k1_sum = sum(X(1:N-1));
 X_k1_k2_sum = sum(X((1:N-1)).*k2(1:N-1));
 X2_k1_sum = sum(X2((1:N-1)));
@@ -231,15 +229,13 @@ X2_k1_sum = sum(X2((1:N-1)));
 while flag == 0
 
     % re-allocate if necessary
-    if N>numel(k)
-        k = (0:numel(k)*2)';
-        k2 = k.^2;
-        k4 = k2.^2;
+    if N>numel(k2)
+        k2 = ((0:numel(k2)*2).^2)';
     end
   
     % iteratively built sum
     k2_sum= k2_sum + k2(N);
-    k4_sum= k4_sum + k4(N);
+    k4_sum= k4_sum + k2(N)*k2(N);
     X_k1_sum = X_k1_sum + X(N);
     X_k1_k2_sum = X_k1_k2_sum + X(N)*k2(N);
     X2_k1_sum = X2_k1_sum + X2(N);

--- a/glottalsource/glottal_models/fzero_plain.m
+++ b/glottalsource/glottal_models/fzero_plain.m
@@ -1,0 +1,124 @@
+%% This function contains copies of algorithms from MATLAB's fzero function.
+% MATLAB's copyright may apply to this files: Copyright 1984-2013 The MathWorks, Inc.
+%
+% fzero_plain is a simple version of MATLAB's fzero function. Since it does
+% not need to process several options and set default values, it is faster
+% than MATLAB's fzero (for simple problems). fzero_plain only contains the
+% plain algorithm's of fzero. 
+function b = fzero_plain(fun,x)
+
+tol = eps;
+
+if numel(x)==1
+    %% find interval
+    fx = fun(x);
+    
+    if fx == 0
+        b = x;
+        return;
+    end
+    
+    if x ~= 0,
+        dx = x/50;
+    else
+        dx = 1/50;
+    end
+    
+    % Find change of sign.
+    twosqrt = sqrt(2);
+    a = x; fa = fx; b = x; fb = fx;
+    
+    while (fa > 0) == (fb > 0)
+        dx = twosqrt*dx;
+        a = x - dx;  fa = fun(a);
+        
+        if (fa > 0) ~= (fb > 0) % check for different sign
+            break
+        end
+        
+        b = x + dx;  fb = fun(b);
+    end
+    
+else
+    %% intervals are provided
+    assert(numel(x) == 2)
+    a = x(1);
+    b = x(2);
+    
+    fa = fun(a);
+    fb = fun(b);
+end
+
+
+%% intervals have been found
+fc = fb;
+assert(sign(fa) ~= sign(fb))
+
+if fa == 0
+    b = a;
+    return
+end
+
+if fb == 0
+    return
+end
+
+%% Main loop, exit from middle of the loop
+while fb ~= 0 && a ~= b
+    % Insure that b is the best result so far, a is the previous
+    % value of b, and c is on the opposite side of the zero from b.
+    if (fb > 0) == (fc > 0)
+        c = a;  fc = fa;
+        d = b - a;  e = d;
+    end
+    if abs(fc) < abs(fb)
+        a = b;    b = c;    c = a;
+        fa = fb;  fb = fc;  fc = fa;
+    end
+    
+    % Convergence test and possible exit
+    m = 0.5*(c - b);
+    toler = 2.0*tol*max(abs(b),1.0);
+    if (abs(m) <= toler) || (fb == 0.0)
+        break
+    end
+    
+    
+    % Choose bisection or interpolation
+    if (abs(e) < toler) || (abs(fa) <= abs(fb))
+        % Bisection
+        d = m;  e = m;
+    else
+        % Interpolation
+        s = fb/fa;
+        if (a == c)
+            % Linear interpolation
+            p = 2.0*m*s;
+            q = 1.0 - s;
+        else
+            % Inverse quadratic interpolation
+            q = fa/fc;
+            r = fb/fc;
+            p = s*(2.0*m*q*(q - r) - (b - a)*(r - 1.0));
+            q = (q - 1.0)*(r - 1.0)*(s - 1.0);
+        end;
+        if p > 0, q = -q; else p = -p; end;
+        % Is interpolated point acceptable
+        if (2.0*p < 3.0*m*q - abs(toler*q)) && (p < abs(0.5*e*q))
+            e = d;  d = p/q;
+        else
+            d = m;  e = m;
+        end;
+    end % Interpolation
+    
+    % Next point
+    a = b;
+    fa = fb;
+    if abs(d) > toler, b = b + d;
+    elseif b > c, b = b - toler;
+    else b = b + toler;
+    end
+    fb = fun(b);
+end
+
+end

--- a/glottalsource/glottal_models/gfm_spec_lf.m
+++ b/glottalsource/glottal_models/gfm_spec_lf.m
@@ -62,13 +62,16 @@ function G = gfm_spec_lf(f, fs, T0, Ee, te, tp, ta)
 
     % e is expressed by an implicit equation
     fb = @(e) 1 - exp(-e.*(T0-Te)) - e.*Ta;         % [1](12) (or [3](p.18) )
-    e = fzero(fb, 1/Ta+eps);
+    e = fzero_plain(fb,1/(Ta+eps));
 
     % a is expressed by another implicit equation   % based on [3]p.18
     % integral{0, T0} ULF(t) dt, where ULF(t) is the LF model equation
     A = (1-exp(-e*(T0-Te)))/(e^2*Ta) - (T0-Te)*exp(-e*(T0-Te))/(e*Ta);
     fa = @(a) (a.^2+wg^2)*sin(wg*Te)*A + wg*exp(-a.*Te) + a.*sin(wg*Te) - wg*cos(wg*Te);
-    a = fzero(fa, [0, 1e9]);
+    % find smaller interval than [0, 1e9]
+    x = [0 1e1 1e2 1e3 1e4 1e5 1e6 1e7 1e8 1e9];
+    idx = find(diff(sign(fa(x))),1);
+    a = fzero_plain(fa, x([idx idx+1]));
 
     % E0 parameter
     E0 = -Ee/(exp(a*Te)*sin(wg*Te));                % [1](5)
@@ -110,5 +113,4 @@ function G = gfm_spec_lf(f, fs, T0, Ee, te, tp, ta)
         keyboard
     %      pause
     end
-
-return
+end

--- a/startup.m
+++ b/startup.m
@@ -23,5 +23,5 @@ end
 
 MATLABVERSION=version('-release'); MATLABVERSION=MATLABVERSION(1:end-1);
 if str2num(MATLABVERSION)>=2015
-    rmpath(genpath([pwd '/external/backcomp_2015']));
+    rmpath(genpath([pwd '/external/backcompatibility_2015']));
 end


### PR DESCRIPTION
The fzero function is called more than 10.000 times (for a 10sec file). Unfortunately, MATLAB's fzero function spends more time in validating and setting (default) values than solving the actual problem (in case of Rd). I stripped off all 'unneeded' stuff from fzero and craeted a new file fzero_plain.m. Compared to fzero, fzero_plain is about 66% faster.

I'm not sure whether you can ship fzero_plain as part of COVAREP, since MATLAB's copyright may apply to fzero_plain!

The changes in 'get_vq_params.m' could theoretically be faster than the previous version but it doesn't seem to be. However, the code should be a little bit more readable