### PR TITLE
Modified startup.m

### DIFF
--- a/startup.m
+++ b/startup.m
@@ -1,19 +1,23 @@
 % This file should be run before running the HOWTO scripts
+function startup
 
-addpath(genpath(pwd));
+current_directory = fileparts(mfilename('fullpath'));
+entries = strsplit(genpath(current_directory), pathsep);
 
-% Remove all .git entries from the path ...
-entries = regexp(path, ['[^',pathsep,']+'],'match');
-idx = find(~cellfun(@isempty,regexp(entries,'\.git')) | ~cellfun(@isempty,regexp(entries,'\.svn')));
-if ~isempty(idx); rmpath(entries{idx}); end
+% helper function to find matching entries
+entry_matcher = @(entries, pattern) ~cellfun(@isempty, strfind(entries, pattern));
 
-% ... s well as the documentation folder
-rmpath(genpath([pwd '/documentation']));
+% Remove all .git and .svn entries from the path
+entries(entry_matcher(entries, '.git') | entry_matcher(entries, '.svn')) = [];
 
-if ~exist('OCTAVE_VERSION')
+% as well as the documentation folder
+entries(entry_matcher(entries, strcat(filesep, 'documentation'))) = [];
+
+if ~exist('OCTAVE_VERSION', 'builtin')
     % Matlab is running
     % Thus remove also the octave helper functions
-    rmpath(genpath([pwd '/external/octave_only']));
+    octave_path = strcat(filesep, 'external', filesep, 'octave_only');
+    entries(entry_matcher(entries, octave_path)) = [];
 else
     % Octave is running
     more off;
@@ -21,9 +25,13 @@ else
     pkg load signal;
 end
 
-MATLABVERSION=version('-release'); MATLABVERSION=MATLABVERSION(1:end-1);
-if str2num(MATLABVERSION)>=2015
-    entries = regexp(path, ['[^',pathsep,']+'],'match');
-    idx = find(~cellfun(@isempty,regexp(entries,'backcompatibility_2015')));
-    if ~isempty(idx); rmpath(entries{idx}); end
+% remove backward compatible functions
+MATLABVERSION=version('-release');
+MATLABVERSION=MATLABVERSION(1:end-1);
+if str2double(MATLABVERSION)>=2015
+    entries(entry_matcher(entries, 'backcompatibility_2015')) = [];
+end
+
+% addpaths
+addpath(strjoin(entries, pathsep));
 end


### PR DESCRIPTION
Modification of startup:
- it is now a function (don't pollute the workspace; can be use in parfor-blocks);
- it can be called from anywhere (previously you had to be in the same working directory);
- before adding the paths, first remove the unwanted parts (.git, documentation, ...) instead of the other way round.
- it is still executed by MATLAB by default when you start MATLAB in CVOAREP's root directory 