### PR TITLE
start/stop option for COVAREP_feature_formant_extraction_perfile

### DIFF
--- a/feature_extraction/COVAREP_feature_formant_extraction_perfile.m
+++ b/feature_extraction/COVAREP_feature_formant_extraction_perfile.m
@@ -90,8 +90,8 @@ assert(all(ismember(options.features, all_features)), ...
 if ismatrix(x), x = x(:, options.channel); end
 
 %% Trim audio to start/stop
-start_index = fs * options.start;
-stop_index = fs * options.stop - 1;
+start_index = fs * options.start + 1;
+stop_index = fs * options.stop;
 if options.stop < 0
     stop_index = numel(x);
 end

--- a/feature_extraction/COVAREP_feature_formant_extraction_perfile.m
+++ b/feature_extraction/COVAREP_feature_formant_extraction_perfile.m
@@ -91,6 +91,7 @@ if ismatrix(x), x = x(:, options.channel); end
 
 %% Trim audio to start/stop
 start_index = round(fs * options.start + 1);
+options.start = (start_index - 1) / fs
 stop_index = round(fs * options.stop);
 if options.stop < 0
     stop_index = numel(x);

--- a/feature_extraction/COVAREP_feature_formant_extraction_perfile.m
+++ b/feature_extraction/COVAREP_feature_formant_extraction_perfile.m
@@ -90,11 +90,12 @@ assert(all(ismember(options.features, all_features)), ...
 if ismatrix(x), x = x(:, options.channel); end
 
 %% Trim audio to start/stop
-start_index = fs * options.start + 1;
-stop_index = fs * options.stop;
+start_index = round(fs * options.start + 1);
+stop_index = round(fs * options.stop);
 if options.stop < 0
     stop_index = numel(x);
 end
+stop_index = min(stop_index, numel(x));
 x = x(start_index:stop_index);
 
 %% Polarity detection


### PR DESCRIPTION
This allows to extract features from only a part of an audio file (timestamps are adjusted accordingly).

I also included a missing dependency: NAQ, QOQ, ... depend on the pitch feature.