### PR TITLE
problem with non-integer indices when fs is not a multiple of 16 kHz

### DIFF
--- a/glottalsource/cpp.m
+++ b/glottalsource/cpp.m
@@ -65,7 +65,7 @@ quef = linspace( 0, frameLen / 1000, NFFT );
 F0lim = [ 500, 50 ]; % Note that this differs from Hillenbrands
                      % settings of 60-300 Hz, to allow for a
                      % fuller range of potential F0 values
-quefLim = fs ./ F0lim;
+quefLim = round(fs ./ F0lim);
 quefSeq = ( quefLim(1):quefLim(2) )';
 
 time_samples = frameLength+1:frameShift:xLen-frameLength;

--- a/glottalsource/iaif_ola.m
+++ b/glottalsource/iaif_ola.m
@@ -62,8 +62,8 @@ function [g,gd,a,ag] = iaif_ola(x,fs,winLen,winShift,p_vt,p_gl,d,hpfilt)
 
     %% Initial settings
     if nargin < 3
-        winLen=25/1000*fs;
-        winShift=5/1000*fs;
+        winLen=round(25/1000*fs);
+        winShift=round(5/1000*fs);
     end
 
     % Use default settings from Tuomo Raitios iaif.m implementation


### PR DESCRIPTION
Added some round() to make glottal source code work for signals of 44.1 kHz