### PR TITLE
A bunch of changes to cpp.m.

### DIFF
--- a/feature_extraction/COVAREP_feature_formant_extraction.m
+++ b/feature_extraction/COVAREP_feature_formant_extraction.m
@@ -62,7 +62,7 @@ if(hasParallelComputing)
         basename=char(basename(1));
         disp(['Analysing file: ' basename])
         try
-            COVAREP_feature_formant_extraction_perfile([in_dir filesep basename '.wav'], options)
+            COVAREP_feature_formant_extraction_perfile([in_dir filesep basename '.wav'], options);
             disp([basename ' successfully analysed'])
         catch err
             warning(['An error occurred while analysing ' basename ': ' getReport(err)])
@@ -74,7 +74,7 @@ else
         basename=char(basename(1));
         disp(['Analysing file: ' basename])
         try
-            COVAREP_feature_formant_extraction_perfile([in_dir filesep basename '.wav'], options)
+            COVAREP_feature_formant_extraction_perfile([in_dir filesep basename '.wav'], options);
             disp([basename ' successfully analysed'])
         catch err
             warning(['An error occurred while analysing ' basename ': ' getReport(err)])

--- a/glottalsource/cpp.m
+++ b/glottalsource/cpp.m
@@ -36,7 +36,7 @@
 % TODO: Use vectorised regression line fitting 
 %       Add band-pass filtering variant
 
-function CPP = cpp( x, fs, smoothOpt, normOpt )
+function CPP = cpp( x, fs, smoothOpt, normOpt, dBScaleOpt )
 
 if nargin < 3
     smoothOpt = 0;

--- a/glottalsource/cpp.m
+++ b/glottalsource/cpp.m
@@ -87,8 +87,8 @@ for n=1:N
    frameMat(1:frameLen,n) = x( frameStart(n):frameStop(n) );
 end
 
-%% Apply Hamming window function
-win = hamming( frameLen );
+%% Apply Hann window function
+win = hanning( frameLen );
 winMat = repmat( win,1,N );
 frameMat(1:frameLen,:) = frameMat(1:frameLen,:) .* winMat;
 

--- a/glottalsource/cpp.m
+++ b/glottalsource/cpp.m
@@ -87,8 +87,8 @@ for n=1:N
    frameMat(1:frameLen,n) = x( frameStart(n):frameStop(n) );
 end
 
-%% Apply Hann window function
-win = hanning( frameLen);
+%% Apply Hamming window function
+win = hamming( frameLen );
 winMat = repmat( win,1,N );
 frameMat(1:frameLen,:) = frameMat(1:frameLen,:) .* winMat;
 

--- a/glottalsource/cpp.m
+++ b/glottalsource/cpp.m
@@ -90,7 +90,7 @@ end
 %% Apply Hann window function
 win = hanning( frameLen);
 winMat = repmat( win,1,N );
-frameMat = frameMat(1:frameLen,:) .* winMat;
+frameMat(1:frameLen,:) = frameMat(1:frameLen,:) .* winMat;
 
 %% Compute magnitude spectrum
 SpecMat = abs( fft( frameMat ) );

--- a/glottalsource/cpp.m
+++ b/glottalsource/cpp.m
@@ -65,7 +65,6 @@ halfLen = round( frameLength / 2 );
 xLen = length( x );
 frameLen = halfLen * 2 + 1;
 NFFT = 2 ^ ( ceil ( log (frameLen) / log(2) ) );
-quef = linspace( 0, frameLen / 1000, NFFT );
 F0lim = [ 500, 50 ]; % Note that this differs from Hillenbrands
                      % settings of 60-300 Hz, to allow for a
                      % fuller range of potential F0 values
@@ -131,5 +130,4 @@ end
 CPP = CepsMax - CepsNorm;
 CPP = [CPP(:) time_samples(:)];
 
-
-
+end

--- a/glottalsource/cpp.m
+++ b/glottalsource/cpp.m
@@ -50,7 +50,7 @@ end
 
 %% Settings
 filterType = 'highpass';
-HPfilt_b = [1 - 0.97];
+HPfilt_b = [1, -0.97];
 frameLength = round( 0.04 * fs );
 
 if smoothOpt


### PR DESCRIPTION
This PR includes a couple of changes to the cpp function:

- fix the pre-emphasis filter coefficients
- prevent removal of zero-padding in the FFT analysis window
- include `dBScaleOpt` in the parameter list
- switch to hamming window (in line with the original implementation)
- minor formatting changes.